### PR TITLE
addProperties method for an entity

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,6 +28,7 @@ A fluent Siren hypermedia representation builder.
             * [.addClass(className)](#module_SirenBuilder..SirenEntity+addClass) ⇒ <code>SirenEntity</code>
             * [.setRel(rel)](#module_SirenBuilder..SirenEntity+setRel) ⇒ <code>SirenEntity</code>
             * [.addProperty(key, value)](#module_SirenBuilder..SirenEntity+addProperty) ⇒ <code>SirenEntity</code>
+            * [.addProperties(obj)](#module_SirenBuilder..SirenEntity+addProperties) ⇒ <code>SirenEntity</code>
             * [.addEntity(rel, entity)](#module_SirenBuilder..SirenEntity+addEntity) ⇒ <code>SirenEntity</code>
             * [.addAction(name, action)](#module_SirenBuilder..SirenEntity+addAction) ⇒ <code>SirenEntity</code>
             * [.addLink(rel, link)](#module_SirenBuilder..SirenEntity+addLink) ⇒ <code>SirenEntity</code>
@@ -212,6 +213,7 @@ Siren entity builder.
     * [.addClass(className)](#module_SirenBuilder..SirenEntity+addClass) ⇒ <code>SirenEntity</code>
     * [.setRel(rel)](#module_SirenBuilder..SirenEntity+setRel) ⇒ <code>SirenEntity</code>
     * [.addProperty(key, value)](#module_SirenBuilder..SirenEntity+addProperty) ⇒ <code>SirenEntity</code>
+    * [.addProperties(obj)](#module_SirenBuilder..SirenEntity+addProperties) ⇒ <code>SirenEntity</code>
     * [.addEntity(rel, entity)](#module_SirenBuilder..SirenEntity+addEntity) ⇒ <code>SirenEntity</code>
     * [.addAction(name, action)](#module_SirenBuilder..SirenEntity+addAction) ⇒ <code>SirenEntity</code>
     * [.addLink(rel, link)](#module_SirenBuilder..SirenEntity+addLink) ⇒ <code>SirenEntity</code>
@@ -257,6 +259,19 @@ Adds a property key-value pair.
 | --- | --- |
 | key | <code>String</code> | 
 | value | <code>Any</code> | 
+
+<a name="module_SirenBuilder..SirenEntity+addProperties"></a>
+
+#### sirenEntity.addProperties(obj) ⇒ <code>SirenEntity</code>
+Adds a property for each key/value pair in the given object.
+
+`Object.keys(obj)` is used to enumerate the keys.
+
+**Kind**: instance method of <code>[SirenEntity](#module_SirenBuilder..SirenEntity)</code>  
+
+| Param | Type |
+| --- | --- |
+| obj | <code>object</code> | 
 
 <a name="module_SirenBuilder..SirenEntity+addEntity"></a>
 

--- a/index.js
+++ b/index.js
@@ -267,6 +267,24 @@ class SirenEntity {
   }
 
   /**
+   * Adds a property for each key/value pair in the given object.
+   *
+   * `Object.keys(obj)` is used to enumerate the keys.
+   *
+   * @param {object} obj
+   * @return {SirenEntity}
+   */
+  addProperties(obj) {
+    const keys = Object.keys(obj);
+    let key;
+    for (let i = 0; i < keys.length; ++i) {
+      key = keys[i];
+      this.addProperty(key, obj[key]);
+    }
+    return this;
+  }
+
+  /**
    * Adds an entity as either an embedded representation or link.
    * @param {(String|String[])} rel
    * @param {(SirenEntity|SirenLink)} entity

--- a/test/index.js
+++ b/test/index.js
@@ -369,6 +369,33 @@ Tap.test('siren example', (t) => {
   t.done();
 });
 
+Tap.test('addProperties', (t) => {
+  const actual = Siren.entity()
+    .addProperty('beforeProp', 'should be kept')
+    .addProperty('name', 'will be overridden')
+    .addProperties({
+      'name': 'overrides previous prop',
+      'orderNumber': 42,
+      'itemCount': 3,
+      'status': 'pending'
+    })
+    .addProperty('afterProp', 'should be kept')
+    .addProperty('status', 'overrides pending')
+    .toJSON();
+  const expected = {
+    'properties': {
+      'orderNumber': 42,
+      'itemCount': 3,
+      'status': 'overrides pending',
+      'name': 'overrides previous prop',
+      'beforeProp': 'should be kept',
+      'afterProp': 'should be kept'
+    }
+  };
+  t.deepEqual(actual, expected);
+  t.done();
+});
+
 Tap.test('readme example', (t) => {
   const actual = Siren.entity()
     .addClass('home')


### PR DESCRIPTION
The use case is, I have some object that I've retrieved from a database. I would like to just map it to properties in the entity. This lets me create the entity in a single chain of functions, for example,

```javascript
const entity = Siren.entity()
  .addClass('widget')
  .addProperties(widget.attrs)
  // ...
  .addLink('self', Siren.link()
    .setHref('...');
```
